### PR TITLE
fixed issue with splash page spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -260,12 +260,20 @@ display: -webkit-flex;
   align-items: center;
 }
 #main_logo {
-  margin: auto;
+  margin-right: 5px;
+  margin-left: 15%;
+  margin-top: auto;
+  margin-bottom: auto;
+  display: inline-block;
 }
 #main_title_div {
-  margin: auto;
+  margin-left: 5px;
+  margin-right: auto;
+  margin-top: auto;
+  margin-bottom: auto;
   align-content: left;
   padding-left: 5%;
+  display: inline-block;
 }
 #main_title {
   font-family: 'Exo';


### PR DESCRIPTION
I changed the margins on the CSS for the logo and text, and this is how it looks now:

<img width="1680" alt="screen shot 2018-09-19 at 9 19 39 am" src="https://user-images.githubusercontent.com/33071909/45730069-55725680-bbed-11e8-9cd0-8fc84ab71d7f.png">
